### PR TITLE
Add notifications kill switch via SiteSettings admin panel

### DIFF
--- a/backend/apps/core/admin.py
+++ b/backend/apps/core/admin.py
@@ -48,7 +48,7 @@ def _get_panel_context():
 
 @admin.register(SiteSettings)
 class SiteSettingsAdmin(admin.ModelAdmin):
-    fields = ['tournament_id', 'pick_window_days', 'api_paused']
+    fields = ['tournament_id', 'pick_window_days', 'api_paused', 'notifications_paused']
     change_form_template = 'admin/core/sitesettings/change_form.html'
 
     def has_add_permission(self, request):
@@ -103,6 +103,11 @@ class SiteSettingsAdmin(admin.ModelAdmin):
                 'toggle-api-pause/',
                 self.admin_site.admin_view(self.toggle_api_pause_view),
                 name='sitesettings_toggle_api_pause',
+            ),
+            path(
+                'toggle-notifications-pause/',
+                self.admin_site.admin_view(self.toggle_notifications_pause_view),
+                name='sitesettings_toggle_notifications_pause',
             ),
         ]
         return custom + urls
@@ -250,6 +255,16 @@ class SiteSettingsAdmin(admin.ModelAdmin):
         settings.save()
         state = 'PAUSED' if settings.api_paused else 'RESUMED'
         messages.success(request, f'CricAPI calls {state}.')
+        return redirect(self._settings_change_url(request))
+
+    def toggle_notifications_pause_view(self, request):
+        if request.method != 'POST':
+            return redirect(self._settings_change_url(request))
+        settings = SiteSettings.get()
+        settings.notifications_paused = not settings.notifications_paused
+        settings.save()
+        state = 'PAUSED' if settings.notifications_paused else 'RESUMED'
+        messages.success(request, f'Notifications {state}.')
         return redirect(self._settings_change_url(request))
 
     # ------------------------------------------------------------------

--- a/backend/apps/core/migrations/0005_sitesettings_notifications_paused.py
+++ b/backend/apps/core/migrations/0005_sitesettings_notifications_paused.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0004_sitesettings_api_paused_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitesettings',
+            name='notifications_paused',
+            field=models.BooleanField(
+                default=False,
+                help_text='Silence all push and in-app notifications. Safe to enable during deployments or testing.',
+            ),
+        ),
+    ]

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -20,6 +20,10 @@ class SiteSettings(models.Model):
         default=False,
         help_text='Pause all CricAPI calls (live score polling + schedule fetch). Use when API has issues.',
     )
+    notifications_paused = models.BooleanField(
+        default=False,
+        help_text='Silence all push and in-app notifications. Safe to enable during deployments or testing.',
+    )
 
     class Meta:
         verbose_name = 'Site Settings'

--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -15,6 +15,11 @@ def notify_pick_result(selection_id, match_id):
     Notify a user that their pick result is available.
     Creates an in-app notification and sends a Web Push if they have subscriptions.
     """
+    from apps.core.models import SiteSettings
+    if SiteSettings.get().notifications_paused:
+        logger.info('notify_pick_result: notifications paused (SiteSettings), skipping')
+        return
+
     from django.contrib.auth.models import User
     from teams.models import Match, Selection
     from apps.notifications.models import Notification, PushSubscription
@@ -64,6 +69,11 @@ def notify_rank_change(new_leader, match_id, prev_leader=None):
     Create an in-app Notification for ALL active users when rank #1 changes,
     and send a Web Push to each user's subscribed devices.
     """
+    from apps.core.models import SiteSettings
+    if SiteSettings.get().notifications_paused:
+        logger.info('notify_rank_change: notifications paused (SiteSettings), skipping')
+        return
+
     from django.contrib.auth.models import User
     from apps.notifications.models import Notification, PushSubscription
     from apps.notifications.utils import send_push_notification
@@ -100,6 +110,11 @@ def send_custom_notification(title, message, url, user_ids):
     Send an admin-authored custom notification to a list of users.
     Creates in-app Notification records and sends Web Push to subscribers.
     """
+    from apps.core.models import SiteSettings
+    if SiteSettings.get().notifications_paused:
+        logger.info('send_custom_notification: notifications paused (SiteSettings), skipping')
+        return {'in_app': 0, 'push': 0}
+
     from django.contrib.auth.models import User
     from apps.notifications.models import Notification, PushSubscription
     from apps.notifications.utils import send_push_notification
@@ -159,6 +174,11 @@ def send_pick_reminders():
     Redis cache prevents duplicate sends within each window.
     No in-app notification — the sticky dropdown notice already covers that.
     """
+    from apps.core.models import SiteSettings
+    if SiteSettings.get().notifications_paused:
+        logger.info('send_pick_reminders: notifications paused (SiteSettings), skipping')
+        return {'sent': 0}
+
     from django.core.cache import cache
     from teams.models import Match, Selection
     from apps.notifications.models import PushSubscription
@@ -217,6 +237,11 @@ def notify_personal_rank_changes(changes, match_id):
     Notify each user whose rank moved after a match result.
     changes: [{'user_id': int, 'old_rank': int, 'new_rank': int, 'moved_up': bool}]
     """
+    from apps.core.models import SiteSettings
+    if SiteSettings.get().notifications_paused:
+        logger.info('notify_personal_rank_changes: notifications paused (SiteSettings), skipping')
+        return
+
     from django.contrib.auth.models import User
     from apps.notifications.models import Notification, PushSubscription
     from apps.notifications.utils import send_push_notification
@@ -258,6 +283,11 @@ def notify_tournament_over(match_id, top3_text):
     Notify all active approved users that the tournament is over with top-3 results.
     Fired once after the Final match snapshot is taken.
     """
+    from apps.core.models import SiteSettings
+    if SiteSettings.get().notifications_paused:
+        logger.info('notify_tournament_over: notifications paused (SiteSettings), skipping')
+        return
+
     from django.contrib.auth.models import User
     from apps.notifications.models import Notification, PushSubscription
     from apps.notifications.utils import send_push_notification

--- a/backend/apps/notifications/utils.py
+++ b/backend/apps/notifications/utils.py
@@ -16,6 +16,11 @@ def send_push_notification(subscription, title, body, url='/', tag=None):
     Deletes the subscription if it returns 404/410 (expired/unsubscribed).
     Returns True on success, False otherwise.
     """
+    from apps.core.models import SiteSettings
+    if SiteSettings.get().notifications_paused:
+        logger.debug('Notifications paused (SiteSettings) — push skipped')
+        return False
+
     try:
         from pywebpush import WebPushException, webpush
     except ImportError:

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -211,6 +211,9 @@ CRICKET_API_KEY = os.environ.get('CRIC_API_KEY', '')
 CRICKET_TOURNAMENT_ID = os.environ.get('CRIC_TOURNAMENT_ID', '')
 CRICKET_API_DAILY_LIMIT = int(os.environ.get('CRICKET_API_DAILY_LIMIT', '100'))
 
+# Football API (football-data.org)
+FOOTBALL_DATA_API_KEY = os.environ.get('FOOTBALL_DATA_API_KEY', '')
+
 # drf-spectacular (API docs)
 SPECTACULAR_SETTINGS = {
     'TITLE': 'CricFun API',


### PR DESCRIPTION
Adds notifications_paused boolean to SiteSettings (singleton admin model). When enabled, all push and in-app notification tasks return early with no side effects. Toggle button added to admin panel alongside existing api_paused. Also adds FOOTBALL_DATA_API_KEY to settings (reads from env, harmless if absent).