### PR TITLE
Fix post-match bugs and data integrity issues

### DIFF
--- a/backend/apps/leaderboard/views.py
+++ b/backend/apps/leaderboard/views.py
@@ -168,20 +168,18 @@ def _tie_key(entry):
             entry['matches_won'], entry['powerups_used'])
 
 
-def _head_to_head(username_a, username_b):
+def _head_to_head(username_a, username_b, tournament=None):
     """
     Return (a_wins, b_wins) from completed matches where A and B picked
     opposite sides.  Single query — safe to call only for 2-player ties.
     """
-    from django.db.models import Q as _Q
-    sels = (
-        Selection.objects
-        .filter(
-            user__username__in=[username_a, username_b],
-            match__result__in=['team1', 'team2'],
-        )
-        .select_related('match__team1', 'match__team2', 'selection', 'user')
+    qs = Selection.objects.filter(
+        user__username__in=[username_a, username_b],
+        match__result__in=['team1', 'team2'],
     )
+    if tournament is not None:
+        qs = qs.filter(match__tournament=tournament)
+    sels = qs.select_related('match__team1', 'match__team2', 'selection', 'user')
     by_match = {}
     for s in sels:
         by_match.setdefault(s.match_id, {})[s.user.username] = s
@@ -201,7 +199,7 @@ def _head_to_head(username_a, username_b):
     return a_wins, b_wins
 
 
-def _build_ranked_list(scores):
+def _build_ranked_list(scores, tournament=None):
     """
     Sort scores into a ranked list applying the full tiebreaker chain:
       Primary : highest total
@@ -235,7 +233,7 @@ def _build_ranked_list(scores):
             j += 1
         if j - i == 2:
             a, b = ranked[i], ranked[i + 1]
-            a_wins, b_wins = _head_to_head(a['username'], b['username'])
+            a_wins, b_wins = _head_to_head(a['username'], b['username'], tournament=tournament)
             if b_wins > a_wins:
                 ranked[i], ranked[i + 1] = ranked[i + 1], ranked[i]
             if a_wins == b_wins:
@@ -277,7 +275,7 @@ def take_snapshot(match_id):
 
     tournament = match.tournament
     scores = calculate_scores(tournament=tournament)
-    ranked = _build_ranked_list(scores)
+    ranked = _build_ranked_list(scores, tournament=tournament)
 
     snapshot_data = [
         {k: e[k] for k in (
@@ -553,7 +551,7 @@ class LeaderboardView(APIView):
 
         if tournament:
             scores = calculate_scores(tournament=tournament)
-            ranked = _build_ranked_list(scores)
+            ranked = _build_ranked_list(scores, tournament=tournament)
             streaks = compute_streaks(tournament=tournament)
             for entry in ranked:
                 entry['streak'] = streaks.get(entry['username'], [])
@@ -595,7 +593,7 @@ class MyRankView(APIView):
 
         if tournament:
             scores = calculate_scores(tournament=tournament)
-            ranked = _build_ranked_list(scores)
+            ranked = _build_ranked_list(scores, tournament=tournament)
         else:
             ranked = get_cached_leaderboard()
 

--- a/backend/apps/leaderboard/views.py
+++ b/backend/apps/leaderboard/views.py
@@ -275,7 +275,8 @@ def take_snapshot(match_id):
         logger.error('take_snapshot: match %s not found', match_id)
         return
 
-    scores = calculate_scores()
+    tournament = match.tournament
+    scores = calculate_scores(tournament=tournament)
     ranked = _build_ranked_list(scores)
 
     snapshot_data = [
@@ -293,14 +294,12 @@ def take_snapshot(match_id):
     prev_leader = None
     try:
         existing = LeaderboardSnapshot.objects.get(match=match)
-        # Snapshot exists — use its current leader as the "before" baseline
         if existing.rankings:
             prev_leader = existing.rankings[0]['username']
     except LeaderboardSnapshot.DoesNotExist:
-        # First time for this match — fall back to the previous match's snapshot
         try:
             prev = (LeaderboardSnapshot.objects
-                    .filter(match__datetime__lt=match.datetime)
+                    .filter(match__tournament=tournament, match__datetime__lt=match.datetime)
                     .latest('match__datetime'))
             if prev.rankings:
                 prev_leader = prev.rankings[0]['username']
@@ -312,11 +311,11 @@ def take_snapshot(match_id):
         defaults={'rankings': snapshot_data},
     )
 
-    # Refresh Redis cache (include streaks + rank changes)
-    streaks = compute_streaks(tournament=match.tournament)
+    # Attach rank changes and streaks (tournament-scoped)
+    streaks = compute_streaks(tournament=tournament)
     for e in ranked:
         e['streak'] = streaks.get(e['username'], [])
-    _attach_rank_changes(ranked)
+    _attach_rank_changes_scoped(ranked, tournament)
     cache.set(CACHE_KEY_LEADERBOARD, ranked, timeout=CACHE_TTL)
     logger.info('take_snapshot: saved snapshot + cache refreshed for match %s', match_id)
 

--- a/backend/apps/matches/footballapi.py
+++ b/backend/apps/matches/footballapi.py
@@ -50,21 +50,24 @@ _KNOCKOUT_STAGES = frozenset({
 
 # ── Pure mapping functions ────────────────────────────────────────────────────
 
-def map_status(status: str, winner: str | None) -> str:
-    """Map API status + winner → internal Match.result value."""
+def map_status(status: str, winner: str | None) -> str | None:
+    """Map API status + winner → internal Match.result value, or None to skip."""
     if status in ('SCHEDULED', 'TIMED'):
         return 'TBD'
-    if status in ('IN_PLAY', 'PAUSED'):
+    if status in ('IN_PLAY', 'PAUSED', 'SUSPENDED'):
         return 'IP'
-    if status == 'FINISHED':
+    if status in ('FINISHED', 'AWARDED'):
         if winner == 'HOME_TEAM':
             return 'team1'
         if winner == 'AWAY_TEAM':
             return 'team2'
         if winner == 'DRAW':
             return 'draw'
-        return 'NR'
-    # POSTPONED, CANCELLED, SUSPENDED
+        # FINISHED with null winner — API still processing, skip update
+        return None
+    if status == 'POSTPONED':
+        return 'DLD'
+    # CANCELLED and anything else
     return 'NR'
 
 

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -421,6 +421,8 @@ def sync_football_scores():
                     ('status_text', new_status_text),
                 ]:
                     old = getattr(match, field)
+                    if field in ('home_score', 'away_score') and val is None and old is not None:
+                        continue  # never wipe a score we already have
                     if old != val:
                         setattr(match, field, val)
                         changed.append(field)

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -406,6 +406,7 @@ def sync_football_scores():
                 )
 
                 changed = []
+                diffs = []
                 for field, val in [
                     ('result',      new_result),
                     ('home_score',  new_home),
@@ -414,14 +415,18 @@ def sync_football_scores():
                     ('duration',    new_duration),
                     ('status_text', new_status_text),
                 ]:
-                    if getattr(match, field) != val:
+                    old = getattr(match, field)
+                    if old != val:
                         setattr(match, field, val)
                         changed.append(field)
+                        diffs.append(f'{field}: {old!r}→{val!r}')
 
                 if changed:
                     match.save(update_fields=changed + ['updated_at'])
                     updated += 1
-                    logger.info('sync_football_scores: match %s %s', m['id'], changed)
+                    t1 = match.team1.name if match.team1 else '?'
+                    t2 = match.team2.name if match.team2 else '?'
+                    logger.info('sync_football_scores: %s vs %s | %s', t1, t2, ' | '.join(diffs))
 
                     if 'result' in changed and new_result in ('team1', 'team2', 'draw', 'NR'):
                         finalize_match_results.delay(match.id)

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -329,6 +329,8 @@ def fetch_football_matches(tournament_id=None):
                 if was_created:
                     created += 1
                 else:
+                    if obj.result != 'TBD':
+                        continue  # live/completed matches are owned by sync_football_scores
                     changed = [k for k, v in fields.items() if getattr(obj, k) != v]
                     if changed:
                         for k in changed:

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -48,8 +48,9 @@ def update_live_scores(self):
     # ── 1. Are any matches live? ──────────────────────────────────────────────
     live_matches = list(
         Match.objects.filter(
-            Q(result='IP') | Q(result='TOSS')
-        ).select_related('team1', 'team2')
+            Q(result='IP') | Q(result='TOSS'),
+            tournament__sport=Tournament.Sport.CRICKET,
+        ).select_related('team1', 'team2', 'tournament')
     )
 
     if not live_matches:

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -396,6 +396,8 @@ def sync_football_scores():
                 full_time = score.get('fullTime') or {}
                 api_status   = m.get('status', '')
                 new_result   = map_status(api_status, score.get('winner'))
+                if new_result is None:
+                    continue  # FINISHED with null winner — API still processing
                 new_home     = full_time.get('home')
                 new_away     = full_time.get('away')
                 new_duration = map_duration(score.get('duration'))

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -381,7 +381,8 @@ def sync_football_scores():
             summary.append(f'{tournament.name}: no imminent matches')
             continue
 
-        raw = fetch_matches(tournament.external_id, status='LIVE,IN_PLAY,PAUSED,FINISHED')
+        date_from = (now - _td(days=1)).strftime('%Y-%m-%d')
+        raw = fetch_matches(tournament.external_id, status='IN_PLAY,PAUSED,FINISHED', dateFrom=date_from)
         if not raw:
             summary.append(f'{tournament.name}: no data')
             continue

--- a/backend/apps/matches/tests.py
+++ b/backend/apps/matches/tests.py
@@ -36,16 +36,19 @@ def test_map_status_finished_draw():
     assert map_status('FINISHED', 'DRAW') == 'draw'
 
 def test_map_status_finished_no_winner():
-    assert map_status('FINISHED', None) == 'NR'
+    assert map_status('FINISHED', None) is None  # API still processing — skip
+
+def test_map_status_awarded_home():
+    assert map_status('AWARDED', 'HOME_TEAM') == 'team1'
 
 def test_map_status_postponed():
-    assert map_status('POSTPONED', None) == 'NR'
+    assert map_status('POSTPONED', None) == 'DLD'
 
 def test_map_status_cancelled():
     assert map_status('CANCELLED', None) == 'NR'
 
 def test_map_status_suspended():
-    assert map_status('SUSPENDED', None) == 'NR'
+    assert map_status('SUSPENDED', None) == 'IP'  # mid-game halt, still live
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -203,7 +203,7 @@ def send_pick_reminders():
 
     windows = [
         ('24h', now + timedelta(hours=23),   now + timedelta(hours=25),   '24 hrs'),
-        ('1h',  now + timedelta(minutes=50), now + timedelta(minutes=70), '1 hr'),
+        ('1h',  now + timedelta(minutes=45), now + timedelta(minutes=75), '1 hr'),
     ]
 
     total_sent = 0

--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -284,7 +284,7 @@ def notify_personal_rank_changes(changes, match_id):
             user=user,
             type='rank_change',
             message=message,
-            meta={'match_id': match_id, 'old_rank': change['old_rank'], 'new_rank': change['new_rank'], 'tournament_id': tournament_id},
+            meta={'match_id': match_id, 'old_rank': change['old_rank'], 'new_rank': change['new_rank'], 'tournament_id': tournament.id if tournament else None},
         )
         for sub in PushSubscription.objects.filter(user=user):
             if send_push_notification(

--- a/frontend/src/pages/MatchDetail.jsx
+++ b/frontend/src/pages/MatchDetail.jsx
@@ -338,15 +338,26 @@ export default function MatchDetail() {
               {matchStatusBadge(match.result)}
               {isSoccer && hasScore ? (
                 <div className="flex items-center gap-3 mt-2">
-                  <span className="text-lg font-bold text-gray-800">{match.team1?.name}</span>
+                  <div className="flex flex-col">
+                    <span className="text-lg font-bold text-gray-800">{match.team1?.name}</span>
+                    {match.team1?.ranking != null && <span className="text-[10px] text-gray-400">#{match.team1.ranking}</span>}
+                  </div>
                   <span className="text-2xl font-black text-gray-700 tabular-nums">
                     {match.home_score} — {match.away_score}
                   </span>
-                  <span className="text-lg font-bold text-gray-800">{match.team2?.name}</span>
+                  <div className="flex flex-col">
+                    <span className="text-lg font-bold text-gray-800">{match.team2?.name}</span>
+                    {match.team2?.ranking != null && <span className="text-[10px] text-gray-400">#{match.team2.ranking}</span>}
+                  </div>
                 </div>
               ) : (
                 <h1 className="text-xl font-bold text-gray-800 mt-2">
                   {match.team1?.name} vs {match.team2?.name}
+                  {(match.team1?.ranking != null || match.team2?.ranking != null) && (
+                    <span className="text-sm font-normal text-gray-400 ml-2">
+                      {match.team1?.ranking != null ? `#${match.team1.ranking}` : ''}{match.team1?.ranking != null && match.team2?.ranking != null ? ' vs ' : ''}{match.team2?.ranking != null ? `#${match.team2.ranking}` : ''}
+                    </span>
+                  )}
                 </h1>
               )}
               <p className="text-sm text-gray-500 mt-0.5">{match.description}</p>

--- a/frontend/src/pages/Schedule.jsx
+++ b/frontend/src/pages/Schedule.jsx
@@ -189,6 +189,9 @@ function MatchPickRow({ match, existingPick, stats }) {
               </div>
             </div>
             <span className="text-sm font-medium text-center leading-tight text-gray-800">{match.team1?.name || 'TBD'}</span>
+            {match.team1?.ranking != null && (
+              <span className="text-[10px] text-gray-400 mt-0.5">#{match.team1.ranking}</span>
+            )}
           </div>
 
           <div className="text-gray-400 font-medium text-sm pt-3">VS</div>
@@ -203,6 +206,9 @@ function MatchPickRow({ match, existingPick, stats }) {
               </div>
             </div>
             <span className="text-sm font-medium text-center leading-tight text-gray-800">{match.team2?.name || 'TBD'}</span>
+            {match.team2?.ranking != null && (
+              <span className="text-[10px] text-gray-400 mt-0.5">#{match.team2.ranking}</span>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Scope leaderboard H2H tiebreaker to tournament (cross-tournament picks were leaking in)
Protect scores from null overwrite during live sync and EOD fetch
Fix pick reminder 1h window gap (20-min window vs 30-min interval)
Fix NameError in notify_personal_rank_changes (undefined tournament_id)