### PR TITLE
Fix tournament scoping, data integrity, and notification bugs

### DIFF
--- a/backend/apps/core/admin.py
+++ b/backend/apps/core/admin.py
@@ -233,14 +233,15 @@ class SiteSettingsAdmin(admin.ModelAdmin):
         completed = list(
             Match.objects.filter(
                 Q(result='team1') | Q(result='team2') | Q(result='NR')
-            ).order_by('datetime')
+            ).select_related('tournament').order_by('datetime')
         )
         existing_ids = set(LeaderboardSnapshot.objects.values_list('match_id', flat=True))
         to_fill = [m for m in completed if m.id not in existing_ids]
 
         for match in to_fill:
-            scores        = calculate_scores(upto_match_id=match.id)
-            ranked        = _build_ranked_list(scores)
+            tournament    = match.tournament
+            scores        = calculate_scores(upto_match_id=match.id, tournament=tournament)
+            ranked        = _build_ranked_list(scores, tournament=tournament)
             snapshot_data = [
                 {k: e[k] for k in (
                     'rank', 'username', 'user_id', 'total',
@@ -252,13 +253,11 @@ class SiteSettingsAdmin(admin.ModelAdmin):
                 match=match, defaults={'rankings': snapshot_data}
             )
 
-        # Refresh Redis cache
-        final = _build_ranked_list(calculate_scores())
-        django_cache.set(CACHE_KEY_LEADERBOARD, final, timeout=CACHE_TTL)
+        django_cache.delete(CACHE_KEY_LEADERBOARD)
 
         messages.success(
             request,
-            f'Backfilled {len(to_fill)} snapshot(s). Redis cache refreshed.'
+            f'Backfilled {len(to_fill)} snapshot(s). Cache cleared.'
         )
         return redirect(self._settings_change_url(request))
 
@@ -280,13 +279,14 @@ class SiteSettingsAdmin(admin.ModelAdmin):
         completed = list(
             Match.objects.filter(
                 Q(result='team1') | Q(result='team2') | Q(result='NR')
-            ).order_by('datetime')
+            ).select_related('tournament').order_by('datetime')
         )
 
         # Force-regenerate every snapshot regardless of whether it exists
         for match in completed:
-            scores        = calculate_scores(upto_match_id=match.id)
-            ranked        = _build_ranked_list(scores)
+            tournament    = match.tournament
+            scores        = calculate_scores(upto_match_id=match.id, tournament=tournament)
+            ranked        = _build_ranked_list(scores, tournament=tournament)
             snapshot_data = [
                 {k: e[k] for k in (
                     'rank', 'username', 'user_id', 'total',
@@ -298,13 +298,11 @@ class SiteSettingsAdmin(admin.ModelAdmin):
                 match=match, defaults={'rankings': snapshot_data}
             )
 
-        # Refresh Redis cache with the full current standings
-        final = _build_ranked_list(calculate_scores())
-        django_cache.set(CACHE_KEY_LEADERBOARD, final, timeout=CACHE_TTL)
+        django_cache.delete(CACHE_KEY_LEADERBOARD)
 
         messages.success(
             request,
-            f'Recalculated {len(completed)} snapshot(s) from scratch. Redis cache refreshed.'
+            f'Recalculated {len(completed)} snapshot(s) from scratch. Cache cleared.'
         )
         return redirect(self._settings_change_url(request))
 

--- a/backend/apps/leaderboard/management/commands/backfill_snapshots.py
+++ b/backend/apps/leaderboard/management/commands/backfill_snapshots.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         completed = list(
             Match.objects.filter(
                 Q(result='team1') | Q(result='team2') | Q(result='NR')
-            ).order_by('datetime')
+            ).select_related('tournament').order_by('datetime')
         )
 
         if not options['force']:
@@ -52,8 +52,9 @@ class Command(BaseCommand):
         self.stdout.write(f'Backfilling {total} match snapshot(s)...')
 
         for i, match in enumerate(to_fill, 1):
-            scores = calculate_scores(upto_match_id=match.id)
-            ranked = _build_ranked_list(scores)
+            tournament = match.tournament
+            scores = calculate_scores(upto_match_id=match.id, tournament=tournament)
+            ranked = _build_ranked_list(scores, tournament=tournament)
             snapshot_data = [
                 {k: e[k] for k in (
                     'rank', 'username', 'user_id', 'total',
@@ -67,9 +68,8 @@ class Command(BaseCommand):
             )
             self.stdout.write(f'  [{i}/{total}] {match}')
 
-        # Refresh Redis cache with the final (current) state
-        final = _build_ranked_list(calculate_scores())
-        cache.set(CACHE_KEY_LEADERBOARD, final, timeout=CACHE_TTL)
+        # Redis cache is rebuilt on the next leaderboard request — just clear it
+        cache.delete(CACHE_KEY_LEADERBOARD)
 
         self.stdout.write(self.style.SUCCESS(
             f'Done. {total} snapshot(s) created/updated. Redis cache refreshed.'


### PR DESCRIPTION
Scope leaderboard H2H tiebreaker, backfill command, and admin panel recalculate to tournament (charts were showing wrong ranks/points)
Protect live scores from null overwrite during sync and EOD fetch
Fix pick reminder 1h window gap (20-min window vs 30-min task interval)
Fix NameError in notify_personal_rank_changes (undefined tournament_id)