### PR TITLE
Fix stale pick state, pick distribution refresh, and powerup availability

### DIFF
--- a/frontend/src/components/home/HomeMatchCard.jsx
+++ b/frontend/src/components/home/HomeMatchCard.jsx
@@ -138,6 +138,7 @@ export default function HomeMatchCard({ match, pick, stats, isDragTarget, onDrag
       }
       qc.invalidateQueries({ queryKey: ['picks', 'active'] })
       qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+      qc.invalidateQueries({ queryKey: ['match', match.id, 'selections'] })
       setShowChangePick(false)
     } catch (err) {
       setError(err.response?.data?.detail ?? err.response?.data?.non_field_errors?.[0] ?? err.response?.data?.draw?.[0] ?? 'Failed to save')
@@ -151,6 +152,7 @@ export default function HomeMatchCard({ match, pick, stats, isDragTarget, onDrag
       await picksAPI.remove(pick.id)
       qc.invalidateQueries({ queryKey: ['picks', 'active'] })
       qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+      qc.invalidateQueries({ queryKey: ['match', match.id, 'selections'] })
       setShowChangePick(false)
     } catch (err) {
       setError(err.response?.data?.error ?? 'Failed to remove')

--- a/frontend/src/pages/MatchDetail.jsx
+++ b/frontend/src/pages/MatchDetail.jsx
@@ -12,14 +12,14 @@ import { useCountdown } from '@/hooks/useCountdown'
 
 const POWERUP_META = {
   cricket: {
-    hidden:      { emoji: '🕵️', label: 'Hidden' },
-    fake:        { emoji: '🃏', label: 'Googly' },
-    no_negative: { emoji: '🛡️', label: 'The Wall' },
+    hidden:      { emoji: '🕵️', label: 'Hidden',      key: 'hidden_count' },
+    fake:        { emoji: '🃏', label: 'Googly',      key: 'fake_count' },
+    no_negative: { emoji: '🛡️', label: 'The Wall',   key: 'no_negative_count' },
   },
   soccer: {
-    hidden:      { emoji: '🕵️', label: 'Hidden' },
-    fake:        { emoji: '🪄', label: 'Dummy' },
-    no_negative: { emoji: '🧤', label: 'Clean Sheet' },
+    hidden:      { emoji: '🕵️', label: 'Hidden',      key: 'hidden_count' },
+    fake:        { emoji: '🪄', label: 'Dummy',        key: 'fake_count' },
+    no_negative: { emoji: '🧤', label: 'Clean Sheet', key: 'no_negative_count' },
   },
 }
 
@@ -401,6 +401,7 @@ export default function MatchDetail() {
           onPickChange={() => {
             qc.invalidateQueries({ queryKey: ['picks', 'active', tid] })
             qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+            qc.invalidateQueries({ queryKey: ['match', id, 'selections'] })
           }}
         />
       )}

--- a/frontend/src/pages/Schedule.jsx
+++ b/frontend/src/pages/Schedule.jsx
@@ -53,6 +53,10 @@ function MatchPickRow({ match, existingPick, stats }) {
     existingPick?.draw ? 'draw' : (existingPick?.selection ?? null)
   )
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    setSelected(existingPick?.draw ? 'draw' : (existingPick?.selection ?? null))
+  }, [existingPick?.id, existingPick?.draw, existingPick?.selection])
   const [saveError, setSaveError] = useState('')
   const [powerupLoading, setPowerupLoading] = useState(null)
   const [showChangePick, setShowChangePick] = useState(false)
@@ -106,6 +110,7 @@ function MatchPickRow({ match, existingPick, stats }) {
       }
       qc.invalidateQueries({ queryKey: ['picks', 'active'] })
       qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+      qc.invalidateQueries({ queryKey: ['match', match.id, 'selections'] })
       setShowChangePick(false)
     } catch (err) {
       setSaveError(err.response?.data?.detail ?? err.response?.data?.non_field_errors?.[0] ?? err.response?.data?.draw?.[0] ?? 'Failed to save')
@@ -125,6 +130,7 @@ function MatchPickRow({ match, existingPick, stats }) {
       if (existingPick) await picksAPI.remove(existingPick.id)
       qc.invalidateQueries({ queryKey: ['picks', 'active'] })
       qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+      qc.invalidateQueries({ queryKey: ['match', match.id, 'selections'] })
       setShowChangePick(false)
     } catch (err) {
       setSaveError(err.response?.data?.error ?? 'Failed to remove')


### PR DESCRIPTION
- Schedule: sync selected state from existingPick prop via useEffect so cards don't show URGENT when picks query resolves after initial render
- Home/Schedule/MatchDetail: invalidate selections query after pick actions so pick distribution bar updates immediately without a refresh
- MatchDetail: add missing `key` to POWERUP_META so powerup buttons correctly enable/disable based on remaining powerup counts