### PR TITLE
Fix duplicate notifications, result rollback, draw count, and powerup…

### DIFF
--- a/backend/apps/leaderboard/views.py
+++ b/backend/apps/leaderboard/views.py
@@ -559,14 +559,14 @@ class LeaderboardView(APIView):
                 entry['streak'] = streaks.get(entry['username'], [])
             _attach_rank_changes_scoped(ranked, tournament)
             completed = Match.objects.filter(
-                Q(result='team1') | Q(result='team2') | Q(result='NR'),
+                Q(result='team1') | Q(result='team2') | Q(result='draw') | Q(result='NR'),
                 tournament=tournament,
             ).count()
             total = Match.objects.exclude(result='CANC').filter(tournament=tournament).count()
         else:
             ranked = get_cached_leaderboard()
             completed = Match.objects.filter(
-                Q(result='team1') | Q(result='team2') | Q(result='NR')
+                Q(result='team1') | Q(result='team2') | Q(result='draw') | Q(result='NR')
             ).count()
             total = Match.objects.exclude(result='CANC').count()
 

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -424,6 +424,9 @@ def sync_football_scores():
                     old = getattr(match, field)
                     if field in ('home_score', 'away_score') and val is None and old is not None:
                         continue  # never wipe a score we already have
+                    _final = {'team1', 'team2', 'draw', 'NR'}
+                    if field == 'result' and old in _final and val not in _final:
+                        continue  # never roll back from a final result (API fluctuation)
                     if old != val:
                         setattr(match, field, val)
                         changed.append(field)

--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -25,6 +25,8 @@ def notify_pick_result(selection_id, match_id):
     from apps.notifications.models import Notification, PushSubscription
     from apps.notifications.utils import send_push_notification
 
+    from django.core.cache import cache
+
     try:
         sel = Selection.objects.select_related(
             'user', 'match__team1', 'match__team2', 'match__tournament', 'selection',
@@ -32,6 +34,11 @@ def notify_pick_result(selection_id, match_id):
         match = sel.match
     except Selection.DoesNotExist:
         logger.error('notify_pick_result: selection %s not found', selection_id)
+        return
+
+    cache_key = f'pick_result_notified_{match_id}_{sel.user_id}'
+    if cache.get(cache_key):
+        logger.info('notify_pick_result: duplicate skipped for user %s match %s', sel.user_id, match_id)
         return
 
     t1 = match.team1.name if match.team1 else '?'
@@ -64,6 +71,7 @@ def notify_pick_result(selection_id, match_id):
     for sub in PushSubscription.objects.filter(user=sel.user):
         send_push_notification(sub, title='TushFun', body=message, url='/results', tag=f'pick-result-{match_id}')
 
+    cache.set(cache_key, 1, timeout=24 * 3600)
     logger.info('notify_pick_result: notified user %s for selection %s', sel.user_id, selection_id)
 
 

--- a/backend/apps/picks/views.py
+++ b/backend/apps/picks/views.py
@@ -134,7 +134,25 @@ class SelectionViewSet(viewsets.ModelViewSet):
         missing = missing_qs.count()
         urgent_missing = missing_qs.filter(datetime__lte=now + timedelta(hours=24)).count()
 
-        return Response({**powerup_stats, 'missing_picks': missing, 'urgent_missing_picks': urgent_missing, 'pick_window_days': window})
+        # Remaining matches where powerups can be applied (sport-specific rules)
+        remaining_powerup_matches = 0
+        if tournament_id:
+            from teams.models import Tournament
+            try:
+                tournament = Tournament.objects.get(pk=tournament_id)
+                if tournament.sport == Tournament.Sport.SOCCER:
+                    from teams.models import Match as M
+                    remaining_powerup_matches = M.objects.filter(
+                        tournament_id=tournament_id, result='TBD',
+                    ).exclude(description__in=Match._SOCCER_HIGH_STAKES).count()
+                else:
+                    remaining_powerup_matches = Match.objects.filter(
+                        tournament_id=tournament_id, result='TBD', playoff=False,
+                    ).count()
+            except Tournament.DoesNotExist:
+                pass
+
+        return Response({**powerup_stats, 'missing_picks': missing, 'urgent_missing_picks': urgent_missing, 'pick_window_days': window, 'remaining_powerup_matches': remaining_powerup_matches})
 
     @action(detail=True, methods=['post'])
     def powerup(self, request, pk=None):

--- a/frontend/src/pages/Schedule.jsx
+++ b/frontend/src/pages/Schedule.jsx
@@ -412,13 +412,20 @@ export default function Schedule() {
       </div>
 
       {stats && (
-        <div className="stats stats-horizontal bg-gray-50 shadow w-full">
-          {Object.entries(POWERUP_META[currentTournament?.sport ?? 'cricket']).map(([, meta]) => (
-            <div key={meta.key} className="stat place-items-center py-2">
-              <div className="stat-value text-base text-secondary">{stats[meta.key]}</div>
-              <div className="stat-desc text-xs">{meta.emoji} {meta.label}</div>
-            </div>
-          ))}
+        <div>
+          <div className="stats stats-horizontal bg-gray-50 shadow w-full">
+            {Object.entries(POWERUP_META[currentTournament?.sport ?? 'cricket']).map(([, meta]) => (
+              <div key={meta.key} className="stat place-items-center py-2">
+                <div className="stat-value text-base text-secondary">{stats[meta.key]}</div>
+                <div className="stat-desc text-xs">{meta.emoji} {meta.label}</div>
+              </div>
+            ))}
+          </div>
+          {stats.remaining_powerup_matches != null && (
+            <p className="text-xs text-gray-400 text-center mt-1.5">
+              ⏳ {stats.remaining_powerup_matches} match{stats.remaining_powerup_matches !== 1 ? 'es' : ''} remaining to use powerups
+            </p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
… matches

- Prevent sync_football_scores from rolling back a final match result (team1/team2/draw/NR) to IP/TBD due to API status fluctuations
- Add Redis cache dedup in notify_pick_result (24h TTL) to block duplicate notifications if result somehow fires more than once
- Fix leaderboard matches_completed count missing draw results
- Add remaining_powerup_matches to picks stats, sport-aware: cricket excludes playoff matches, soccer excludes QF/SF/3rd/Final
- Show remaining powerup matches note below stats bar on Schedule page