### PR TITLE
Implement soccer Dummy powerup decoy picker

### DIFF
--- a/frontend/src/api/picks.js
+++ b/frontend/src/api/picks.js
@@ -27,7 +27,7 @@ export const picksAPI = {
     return res
   }),
 
-  applyPowerup: (id, type) => api.post(`/picks/${id}/powerup/`, { powerup_type: type }).then(res => {
+  applyPowerup: (id, type, extra = {}) => api.post(`/picks/${id}/powerup/`, { powerup_type: type, ...extra }).then(res => {
     posthog.capture('powerup_applied', { pick_id: id, powerup_type: type })
     return res
   }),

--- a/frontend/src/components/home/HomeMatchCard.jsx
+++ b/frontend/src/components/home/HomeMatchCard.jsx
@@ -60,6 +60,8 @@ export default function HomeMatchCard({ match, pick, stats, isDragTarget, onDrag
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [showChangePick, setShowChangePick] = useState(false)
+  const [showDecoyPicker, setShowDecoyPicker] = useState(false)
+  const [pendingDecoy, setPendingDecoy] = useState(null)
 
   const now = Date.now()
   const dt = new Date(match.datetime)
@@ -161,11 +163,35 @@ export default function HomeMatchCard({ match, pick, stats, isDragTarget, onDrag
 
   async function applyPowerup(type) {
     if (!hasPick || saving) return
+    if (type === 'fake' && !powerup && match.allows_draw) {
+      setShowDecoyPicker(p => !p)
+      setPendingDecoy(null)
+      return
+    }
     setSaving(true); setError('')
     try {
       await picksAPI.applyPowerup(pick.id, type)
       qc.invalidateQueries({ queryKey: ['picks', 'active'] })
       qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+      qc.invalidateQueries({ queryKey: ['match', match.id, 'selections'] })
+    } catch (err) {
+      setError(err.response?.data?.error ?? 'Failed to apply')
+    } finally { setSaving(false) }
+  }
+
+  async function applyFakeWithDecoy(decoyKey) {
+    if (!hasPick || saving) return
+    setSaving(true); setError('')
+    const extra = decoyKey === 'draw'
+      ? { fake_draw: true }
+      : { fake_selection_id: decoyKey === 'team1' ? match.team1?.id : match.team2?.id }
+    try {
+      await picksAPI.applyPowerup(pick.id, 'fake', extra)
+      qc.invalidateQueries({ queryKey: ['picks', 'active'] })
+      qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+      qc.invalidateQueries({ queryKey: ['match', match.id, 'selections'] })
+      setShowDecoyPicker(false)
+      setPendingDecoy(null)
     } catch (err) {
       setError(err.response?.data?.error ?? 'Failed to apply')
     } finally { setSaving(false) }
@@ -438,23 +464,65 @@ export default function HomeMatchCard({ match, pick, stats, isDragTarget, onDrag
 
         {/* Powerup buttons (mobile tap) */}
         {hasPick && !isLocked && !isCompleted && !powersDisabled && !showChangePick && (
-          <div className="flex gap-2 flex-wrap mt-3">
-            {Object.entries(PM).map(([type, { emoji, label, key }]) => {
-              const available = (stats?.[key] ?? 0) > 0
-              const isActive = powerup === type
-              const otherActive = !!powerup && !isActive
-              return (
-                <button key={type} onClick={() => applyPowerup(type)}
-                  disabled={(!available && !isActive) || otherActive || saving}
-                  className="flex-1 py-1.5 rounded-lg text-xs font-medium border transition disabled:opacity-40"
-                  style={isActive
-                    ? { background: '#EEEDFE', color: '#3C3489', borderColor: '#AFA9EC' }
-                    : { background: 'transparent', color: '#6b7280', borderColor: '#e5e7eb' }
-                  }>
-                  {emoji} {label}{isActive ? ' ✓' : ''}
-                </button>
-              )
-            })}
+          <div className="mt-3">
+            <div className="flex gap-2 flex-wrap">
+              {Object.entries(PM).map(([type, { emoji, label, key }]) => {
+                const available = (stats?.[key] ?? 0) > 0
+                const isActive = powerup === type
+                const otherActive = !!powerup && !isActive
+                return (
+                  <button key={type} onClick={() => applyPowerup(type)}
+                    disabled={(!available && !isActive) || otherActive || saving}
+                    className="flex-1 py-1.5 rounded-lg text-xs font-medium border transition disabled:opacity-40"
+                    style={isActive
+                      ? { background: '#EEEDFE', color: '#3C3489', borderColor: '#AFA9EC' }
+                      : { background: 'transparent', color: '#6b7280', borderColor: '#e5e7eb' }
+                    }>
+                    {emoji} {label}{isActive ? ' ✓' : ''}
+                  </button>
+                )
+              })}
+            </div>
+            {showDecoyPicker && !powerup && hasPick && (
+              <div className="mt-2 p-2.5 rounded-lg border" style={{ background: '#FBEAF0', borderColor: '#ED93B1' }}>
+                <p className="text-[9px] font-bold tracking-widest uppercase mb-2" style={{ color: '#72243E' }}>
+                  🪄 Decoy rivals will see
+                </p>
+                <div className="flex gap-2">
+                  {[
+                    { key: 'team1', label: match.team1?.name },
+                    { key: 'draw',  label: 'Draw', glyph: '⚖' },
+                    { key: 'team2', label: match.team2?.name },
+                  ].filter(o => o.key !== (myPickDraw ? 'draw' : t1Picked ? 'team1' : 'team2')).map(o => {
+                    const active = pendingDecoy === o.key
+                    return (
+                      <button key={o.key} onClick={() => setPendingDecoy(active ? null : o.key)}
+                        className="flex-1 flex items-center justify-center gap-1 py-2 px-1.5 rounded-lg text-xs font-bold transition"
+                        style={{ background: active ? '#72243E' : 'white', border: `1.5px solid ${active ? '#72243E' : '#ED93B1'}`, color: active ? '#fff' : '#72243E' }}>
+                        {o.glyph && <span>{o.glyph}</span>}{o.label}{active ? ' ✓' : ''}
+                      </button>
+                    )
+                  })}
+                </div>
+                {pendingDecoy ? (
+                  <div className="flex gap-2 mt-2">
+                    <button onClick={() => applyFakeWithDecoy(pendingDecoy)} disabled={saving}
+                      className="flex-1 py-1.5 rounded-lg text-xs font-bold"
+                      style={{ background: '#72243E', color: '#fff' }}>
+                      {saving ? <span className="loading loading-spinner loading-xs" /> : 'Apply Dummy'}
+                    </button>
+                    <button onClick={() => { setShowDecoyPicker(false); setPendingDecoy(null) }}
+                      className="py-1.5 px-3 rounded-lg text-xs border border-gray-200 text-gray-500">
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <p className="text-[10px] mt-2 leading-snug" style={{ color: '#72243E', opacity: 0.85 }}>
+                    Three outcomes — choose which one to flash as your decoy.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/MatchDetail.jsx
+++ b/frontend/src/pages/MatchDetail.jsx
@@ -31,6 +31,8 @@ function MatchDetailPicker({ match, existingPick, pickStats, PM, onPickChange })
   const [saveError, setSaveError] = useState('')
   const [showChange, setShowChange] = useState(false)
   const [powerupLoading, setPowerupLoading] = useState(null)
+  const [showDecoyPicker, setShowDecoyPicker] = useState(false)
+  const [pendingDecoy, setPendingDecoy] = useState(null)
 
   useEffect(() => {
     setSelected(existingPick?.draw ? 'draw' : (existingPick?.selection ?? null))
@@ -98,11 +100,35 @@ function MatchDetailPicker({ match, existingPick, pickStats, PM, onPickChange })
 
   async function handlePowerup(type) {
     if (!existingPick) return
+    if (type === 'fake' && !appliedPowerup && match.allows_draw) {
+      setShowDecoyPicker(p => !p)
+      setPendingDecoy(null)
+      return
+    }
     setPowerupLoading(type)
     setSaveError('')
     try {
       await picksAPI.applyPowerup(existingPick.id, type)
       onPickChange()
+    } catch (err) {
+      setSaveError(err.response?.data?.error ?? 'Failed to apply powerup')
+    } finally {
+      setPowerupLoading(null)
+    }
+  }
+
+  async function handleApplyFakeWithDecoy(decoyKey) {
+    if (!existingPick) return
+    setPowerupLoading('fake')
+    setSaveError('')
+    const extra = decoyKey === 'draw'
+      ? { fake_draw: true }
+      : { fake_selection_id: decoyKey === 'team1' ? match.team1?.id : match.team2?.id }
+    try {
+      await picksAPI.applyPowerup(existingPick.id, 'fake', extra)
+      onPickChange()
+      setShowDecoyPicker(false)
+      setPendingDecoy(null)
     } catch (err) {
       setSaveError(err.response?.data?.error ?? 'Failed to apply powerup')
     } finally {
@@ -185,26 +211,68 @@ function MatchDetailPicker({ match, existingPick, pickStats, PM, onPickChange })
         )}
 
         {existingPick && !powerupsDisabled && !isLocked && !showChange && (
-          <div className="flex gap-2 flex-wrap mt-3">
-            {Object.entries(PM).map(([type, { emoji, label, key }]) => {
-              const available = (pickStats?.[key] ?? 0) > 0
-              const isActive = appliedPowerup === type
-              const otherApplied = !!appliedPowerup && !isActive
-              return (
-                <button key={type}
-                  onClick={() => handlePowerup(type)}
-                  disabled={(!available && !isActive) || otherApplied || powerupLoading !== null}
-                  className="flex-1 py-1.5 rounded-lg text-xs font-medium border transition disabled:opacity-40"
-                  style={isActive
-                    ? { background: '#EEEDFE', color: '#3C3489', borderColor: '#AFA9EC' }
-                    : { background: 'transparent', color: '#6b7280', borderColor: '#e5e7eb' }
-                  }>
-                  {powerupLoading === type
-                    ? <span className="loading loading-spinner loading-xs" />
-                    : `${emoji} ${label}${isActive ? ' ✓' : ''}`}
-                </button>
-              )
-            })}
+          <div className="mt-3">
+            <div className="flex gap-2 flex-wrap">
+              {Object.entries(PM).map(([type, { emoji, label, key }]) => {
+                const available = (pickStats?.[key] ?? 0) > 0
+                const isActive = appliedPowerup === type
+                const otherApplied = !!appliedPowerup && !isActive
+                return (
+                  <button key={type}
+                    onClick={() => handlePowerup(type)}
+                    disabled={(!available && !isActive) || otherApplied || powerupLoading !== null}
+                    className="flex-1 py-1.5 rounded-lg text-xs font-medium border transition disabled:opacity-40"
+                    style={isActive
+                      ? { background: '#EEEDFE', color: '#3C3489', borderColor: '#AFA9EC' }
+                      : { background: 'transparent', color: '#6b7280', borderColor: '#e5e7eb' }
+                    }>
+                    {powerupLoading === type
+                      ? <span className="loading loading-spinner loading-xs" />
+                      : `${emoji} ${label}${isActive ? ' ✓' : ''}`}
+                  </button>
+                )
+              })}
+            </div>
+            {showDecoyPicker && !appliedPowerup && hasPick && (
+              <div className="mt-2 p-2.5 rounded-lg border" style={{ background: '#FBEAF0', borderColor: '#ED93B1' }}>
+                <p className="text-[9px] font-bold tracking-widest uppercase mb-2" style={{ color: '#72243E' }}>
+                  🪄 Decoy rivals will see
+                </p>
+                <div className="flex gap-2">
+                  {[
+                    { key: 'team1', label: match.team1?.name },
+                    { key: 'draw',  label: 'Draw', glyph: '⚖' },
+                    { key: 'team2', label: match.team2?.name },
+                  ].filter(o => o.key !== (drawSelected ? 'draw' : t1Selected ? 'team1' : 'team2')).map(o => {
+                    const active = pendingDecoy === o.key
+                    return (
+                      <button key={o.key} onClick={() => setPendingDecoy(active ? null : o.key)}
+                        className="flex-1 flex items-center justify-center gap-1 py-2 px-1.5 rounded-lg text-xs font-bold transition"
+                        style={{ background: active ? '#72243E' : 'white', border: `1.5px solid ${active ? '#72243E' : '#ED93B1'}`, color: active ? '#fff' : '#72243E' }}>
+                        {o.glyph && <span>{o.glyph}</span>}{o.label}{active ? ' ✓' : ''}
+                      </button>
+                    )
+                  })}
+                </div>
+                {pendingDecoy ? (
+                  <div className="flex gap-2 mt-2">
+                    <button onClick={() => handleApplyFakeWithDecoy(pendingDecoy)} disabled={powerupLoading !== null}
+                      className="flex-1 py-1.5 rounded-lg text-xs font-bold"
+                      style={{ background: '#72243E', color: '#fff' }}>
+                      {powerupLoading === 'fake' ? <span className="loading loading-spinner loading-xs" /> : 'Apply Dummy'}
+                    </button>
+                    <button onClick={() => { setShowDecoyPicker(false); setPendingDecoy(null) }}
+                      className="py-1.5 px-3 rounded-lg text-xs border border-gray-200 text-gray-500">
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <p className="text-[10px] mt-2 leading-snug" style={{ color: '#72243E', opacity: 0.85 }}>
+                    Three outcomes — choose which one to flash as your decoy.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/Schedule.jsx
+++ b/frontend/src/pages/Schedule.jsx
@@ -53,6 +53,8 @@ function MatchPickRow({ match, existingPick, stats }) {
     existingPick?.draw ? 'draw' : (existingPick?.selection ?? null)
   )
   const [saving, setSaving] = useState(false)
+  const [showDecoyPicker, setShowDecoyPicker] = useState(false)
+  const [pendingDecoy, setPendingDecoy] = useState(null)
 
   useEffect(() => {
     setSelected(existingPick?.draw ? 'draw' : (existingPick?.selection ?? null))
@@ -142,12 +144,37 @@ function MatchPickRow({ match, existingPick, stats }) {
 
   async function handlePowerup(type) {
     if (!existingPick) return
+    if (type === 'fake' && !appliedPowerup && match.allows_draw) {
+      setShowDecoyPicker(p => !p)
+      setPendingDecoy(null)
+      return
+    }
     setPowerupLoading(type)
     setSaveError('')
     try {
       await picksAPI.applyPowerup(existingPick.id, type)
       qc.invalidateQueries({ queryKey: ['picks', 'active'] })
       qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+    } catch (err) {
+      setSaveError(err.response?.data?.error ?? 'Failed to apply powerup')
+    } finally {
+      setPowerupLoading(null)
+    }
+  }
+
+  async function handleApplyFakeWithDecoy(decoyKey) {
+    if (!existingPick) return
+    setPowerupLoading('fake')
+    setSaveError('')
+    const extra = decoyKey === 'draw'
+      ? { fake_draw: true }
+      : { fake_selection_id: decoyKey === 'team1' ? match.team1?.id : match.team2?.id }
+    try {
+      await picksAPI.applyPowerup(existingPick.id, 'fake', extra)
+      qc.invalidateQueries({ queryKey: ['picks', 'active'] })
+      qc.invalidateQueries({ queryKey: ['picks', 'stats'] })
+      setShowDecoyPicker(false)
+      setPendingDecoy(null)
     } catch (err) {
       setSaveError(err.response?.data?.error ?? 'Failed to apply powerup')
     } finally {
@@ -321,27 +348,69 @@ function MatchPickRow({ match, existingPick, stats }) {
 
         {/* PowerPlay buttons */}
         {existingPick && !powerupsDisabled && !isLocked && !showChangePick && (
-          <div className="flex gap-2 flex-wrap mt-3">
-            {Object.entries(PM).map(([type, { emoji, label, key }]) => {
-              const available = (stats?.[key] ?? 0) > 0
-              const isActive = appliedPowerup === type
-              const otherApplied = !!appliedPowerup && !isActive
-              return (
-                <button key={type}
-                  onClick={() => handlePowerup(type)}
-                  disabled={(!available && !isActive) || otherApplied || powerupLoading !== null}
-                  className="flex-1 py-1.5 rounded-lg text-xs font-medium border transition disabled:opacity-40"
-                  style={isActive
-                    ? { background: '#EEEDFE', color: '#3C3489', borderColor: '#AFA9EC' }
-                    : { background: 'transparent', color: '#6b7280', borderColor: '#e5e7eb' }
-                  }>
-                  {powerupLoading === type
-                    ? <span className="loading loading-spinner loading-xs" />
-                    : `${emoji} ${label}${isActive ? ' ✓' : ''}`
-                  }
-                </button>
-              )
-            })}
+          <div className="mt-3">
+            <div className="flex gap-2 flex-wrap">
+              {Object.entries(PM).map(([type, { emoji, label, key }]) => {
+                const available = (stats?.[key] ?? 0) > 0
+                const isActive = appliedPowerup === type
+                const otherApplied = !!appliedPowerup && !isActive
+                return (
+                  <button key={type}
+                    onClick={() => handlePowerup(type)}
+                    disabled={(!available && !isActive) || otherApplied || powerupLoading !== null}
+                    className="flex-1 py-1.5 rounded-lg text-xs font-medium border transition disabled:opacity-40"
+                    style={isActive
+                      ? { background: '#EEEDFE', color: '#3C3489', borderColor: '#AFA9EC' }
+                      : { background: 'transparent', color: '#6b7280', borderColor: '#e5e7eb' }
+                    }>
+                    {powerupLoading === type
+                      ? <span className="loading loading-spinner loading-xs" />
+                      : `${emoji} ${label}${isActive ? ' ✓' : ''}`
+                    }
+                  </button>
+                )
+              })}
+            </div>
+            {showDecoyPicker && !appliedPowerup && hasPick && (
+              <div className="mt-2 p-2.5 rounded-lg border" style={{ background: '#FBEAF0', borderColor: '#ED93B1' }}>
+                <p className="text-[9px] font-bold tracking-widest uppercase mb-2" style={{ color: '#72243E' }}>
+                  🪄 Decoy rivals will see
+                </p>
+                <div className="flex gap-2">
+                  {[
+                    { key: 'team1', label: match.team1?.name },
+                    { key: 'draw',  label: 'Draw', glyph: '⚖' },
+                    { key: 'team2', label: match.team2?.name },
+                  ].filter(o => o.key !== (drawSelected ? 'draw' : t1Selected ? 'team1' : 'team2')).map(o => {
+                    const active = pendingDecoy === o.key
+                    return (
+                      <button key={o.key} onClick={() => setPendingDecoy(active ? null : o.key)}
+                        className="flex-1 flex items-center justify-center gap-1 py-2 px-1.5 rounded-lg text-xs font-bold transition"
+                        style={{ background: active ? '#72243E' : 'white', border: `1.5px solid ${active ? '#72243E' : '#ED93B1'}`, color: active ? '#fff' : '#72243E' }}>
+                        {o.glyph && <span>{o.glyph}</span>}{o.label}{active ? ' ✓' : ''}
+                      </button>
+                    )
+                  })}
+                </div>
+                {pendingDecoy ? (
+                  <div className="flex gap-2 mt-2">
+                    <button onClick={() => handleApplyFakeWithDecoy(pendingDecoy)} disabled={powerupLoading !== null}
+                      className="flex-1 py-1.5 rounded-lg text-xs font-bold"
+                      style={{ background: '#72243E', color: '#fff' }}>
+                      {powerupLoading === 'fake' ? <span className="loading loading-spinner loading-xs" /> : 'Apply Dummy'}
+                    </button>
+                    <button onClick={() => { setShowDecoyPicker(false); setPendingDecoy(null) }}
+                      className="py-1.5 px-3 rounded-lg text-xs border border-gray-200 text-gray-500">
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <p className="text-[10px] mt-2 leading-snug" style={{ color: '#72243E', opacity: 0.85 }}>
+                    Three outcomes — choose which one to flash as your decoy.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
For soccer group-stage matches (allows_draw), clicking Dummy now shows an inline decoy picker instead of submitting immediately. User selects which outcome rivals will see (the 2 they didn't pick), then confirms — submitting fake_selection_id or fake_draw with the powerup in one request.

Cricket Googly continues to apply immediately with no decoy step. Implemented in Home, Schedule, and Match Detail.