### PR TITLE
Fix penalty pick display on Results and enhance streak badges

### DIFF
--- a/backend/apps/leaderboard/views.py
+++ b/backend/apps/leaderboard/views.py
@@ -366,21 +366,26 @@ def take_snapshot(match_id):
 
 def compute_streaks(tournament=None):
     """
-    Return {username: ['W','L','S','N', ...]} for each active user.
+    Return {username: ['W','L','S','N','💀','🛡','🧤', ...]} for each active user.
     Each entry represents one of their last 5 completed matches (oldest → newest).
-      W = picked the winner (or picked draw on a draw result)
-      L = picked the loser
-      S = skipped (no pick placed)
-      N = no result / rain
+      W  = picked the winner (or picked draw on a draw result)
+      L  = picked the loser
+      S  = free skip (no pick, within the allowed skip budget)
+      N  = no result / rain
+      💀 = penalty pick (high-stakes non-picker, or exceeded 5 free skips)
+      🛡 = cricket loss blocked by The Wall (no_negative)
+      🧤 = soccer loss blocked by Clean Sheet (no_negative)
     Cancelled matches are excluded — they don't count toward the 5.
     Scoped to a specific tournament when provided.
     """
+    from django.db.models import Count as _Count
+
     qs = Match.objects.filter(
         Q(result='team1') | Q(result='team2') | Q(result='draw') | Q(result='NR')
     )
     if tournament:
         qs = qs.filter(tournament=tournament)
-    recent_matches = list(qs.order_by('-datetime')[:5])
+    recent_matches = list(qs.select_related('tournament').order_by('-datetime')[:5])
     if not recent_matches:
         return {}
 
@@ -396,36 +401,74 @@ def compute_streaks(tournament=None):
         else:
             winner_map[m.id] = None
 
-    # picks indexed by (match_id, username) → (selection_id, drew)
+    # picks indexed by (match_id, username) → (selection_id, drew, no_negative)
     picks = {}
     for s in (
         Selection.objects
         .filter(match__in=recent_matches)
         .select_related('user')
-        .values('match_id', 'user__username', 'selection_id', 'draw')
+        .values('match_id', 'user__username', 'selection_id', 'draw', 'no_negative')
     ):
-        picks[(s['match_id'], s['user__username'])] = (s['selection_id'], s['draw'])
+        picks[(s['match_id'], s['user__username'])] = (s['selection_id'], s['draw'], s['no_negative'])
 
     usernames = list(User.objects.filter(is_active=True, tournament_enrollments__isnull=False).distinct().values_list('username', flat=True))
+
+    # Pre-compute prior skip counts per (match_id, username) for penalty detection.
+    # For each non-high-stakes recent match, count how many non-HS completed matches
+    # before it each user skipped. ≥ MAX_SKIPPED_ALLOWED → penalty.
+    skip_before = {}  # (match_id, username) -> int
+    non_hs_recent = [m for m in recent_matches if not m.is_high_stakes and winner_map.get(m.id) is not None]
+    for rm in non_hs_recent:
+        # All non-high-stakes completed matches in the same tournament before rm
+        is_soccer = rm.tournament.sport == 'soccer'
+        prior_qs = Match.objects.filter(
+            tournament_id=rm.tournament_id,
+            result__in=('team1', 'team2', 'draw', 'NR'),
+            datetime__lt=rm.datetime,
+        )
+        if is_soccer:
+            prior_qs = prior_qs.exclude(description__in=Match._SOCCER_HIGH_STAKES)
+        else:
+            prior_qs = prior_qs.filter(playoff=False)
+
+        prior_ids = list(prior_qs.values_list('id', flat=True))
+        prior_count = len(prior_ids)
+        if prior_count == 0:
+            for u in usernames:
+                skip_before[(rm.id, u)] = 0
+            continue
+
+        picks_made = dict(
+            Selection.objects.filter(match_id__in=prior_ids)
+            .values('user__username')
+            .annotate(cnt=_Count('id'))
+            .values_list('user__username', 'cnt')
+        )
+        for u in usernames:
+            skip_before[(rm.id, u)] = prior_count - picks_made.get(u, 0)
 
     streaks = {}
     for username in usernames:
         streak = []
-        # recent_matches is desc (newest first) — matches display order
         for m in recent_matches:
             winner = winner_map[m.id]
             if winner is None:
                 streak.append('N')
-            else:
-                pick = picks.get((m.id, username))
-                if pick is None:
-                    streak.append('S')
-                elif winner == 'draw' and pick[1]:
-                    streak.append('W')
-                elif winner != 'draw' and not pick[1] and pick[0] == winner:
-                    streak.append('W')
+                continue
+            pick = picks.get((m.id, username))
+            if pick is None:
+                if m.is_high_stakes or skip_before.get((m.id, username), 0) >= MAX_SKIPPED_ALLOWED:
+                    streak.append('💀')
                 else:
-                    streak.append('L')
+                    streak.append('S')
+            elif winner == 'draw' and pick[1]:
+                streak.append('W')
+            elif winner != 'draw' and not pick[1] and pick[0] == winner:
+                streak.append('W')
+            elif pick[2]:  # no_negative blocked the loss
+                streak.append('🛡' if m.tournament.sport == 'cricket' else '🧤')
+            else:
+                streak.append('L')
         streaks[username] = streak
 
     return streaks

--- a/backend/apps/matches/views.py
+++ b/backend/apps/matches/views.py
@@ -232,23 +232,69 @@ class MatchViewSet(viewsets.ModelViewSet):
                 elif s.no_negative:
                     powerups[s.user.username] = 'no_negative'
 
-        # For completed playoff matches, assign non-pickers to the losing side
+        # Assign non-pickers to the losing side for display on Results page,
+        # mirroring the penalty logic in calculate_scores.
         team1_auto = []
         team2_auto = []
-        if match.playoff and match.result in ('team1', 'team2'):
+        if match.result in ('team1', 'team2', 'draw'):
             from django.contrib.auth.models import User as _User
+            from django.db.models import Count as _Count
+            from teams.models import Selection as _Sel
+
+            MAX_SKIPPED = 5
+
             all_usernames = set(
                 _User.objects.filter(
                     is_active=True,
                     tournament_enrollments__tournament=match.tournament,
                 ).values_list('username', flat=True)
             )
-            picked_usernames = set(sel1_users) | set(sel2_users)
+            picked_usernames = set(sel1_users) | set(sel2_users) | set(sel_draw_users)
             non_pickers = sorted(all_usernames - picked_usernames)
-            if match.result == 'team1':
-                team2_auto = non_pickers
-            else:
-                team1_auto = non_pickers
+
+            if non_pickers:
+                if match.is_high_stakes:
+                    # QF+ / all cricket playoffs: all non-pickers auto-assigned to losing side
+                    penalised = non_pickers
+                else:
+                    # Group stage / R32 / R16: only excess-skip users are penalised
+                    is_soccer = match.tournament.sport == Tournament.Sport.SOCCER
+                    prior_qs = Match.objects.filter(
+                        tournament=match.tournament,
+                        result__in=('team1', 'team2', 'draw', 'NR'),
+                        datetime__lt=match.datetime,
+                    )
+                    if is_soccer:
+                        prior_qs = prior_qs.exclude(description__in=Match._SOCCER_HIGH_STAKES)
+                    else:
+                        prior_qs = prior_qs.filter(playoff=False)
+
+                    prior_ids = list(prior_qs.values_list('id', flat=True))
+                    prior_count = len(prior_ids)
+
+                    if prior_count == 0:
+                        penalised = []
+                    else:
+                        picks_made = dict(
+                            _Sel.objects.filter(
+                                match_id__in=prior_ids,
+                                user__username__in=non_pickers,
+                            ).values('user__username')
+                            .annotate(cnt=_Count('id'))
+                            .values_list('user__username', 'cnt')
+                        )
+                        penalised = [
+                            u for u in non_pickers
+                            if (prior_count - picks_made.get(u, 0)) >= MAX_SKIPPED
+                        ]
+
+                if penalised:
+                    if match.result == 'team1':
+                        team2_auto = penalised
+                    elif match.result == 'team2':
+                        team1_auto = penalised
+                    else:  # draw — assign to team1 side (same as scoring logic)
+                        team1_auto = penalised
 
         return Response({
             'match_id': match.id,

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -318,14 +318,18 @@ export default function Leaderboard() {
                         <div className="flex gap-0.5 mt-0.5">
                           {row.streak.map((s, idx) => (
                             <span key={idx} className={`text-[9px] font-bold px-1 py-px rounded ${
-                              s === 'W' ? 'bg-green-100 text-green-700' :
-                              s === 'L' ? 'bg-red-100 text-red-700' :
-                              s === 'N' ? 'bg-yellow-100 text-yellow-700' :
+                              s === 'W'  ? 'bg-green-100 text-green-700' :
+                              s === 'L'  ? 'bg-red-100 text-red-700' :
+                              s === 'N'  ? 'bg-yellow-100 text-yellow-700' :
+                              s === '💀' ? 'bg-amber-100 text-amber-700' :
+                              (s === '🛡' || s === '🧤') ? 'bg-purple-100 text-purple-700' :
                               'bg-gray-100 text-gray-400'
                             } ${idx === 0 ? (
-                              s === 'W' ? 'ring-1 ring-green-400' :
-                              s === 'L' ? 'ring-1 ring-red-400' :
-                              s === 'N' ? 'ring-1 ring-yellow-400' :
+                              s === 'W'  ? 'ring-1 ring-green-400' :
+                              s === 'L'  ? 'ring-1 ring-red-400' :
+                              s === 'N'  ? 'ring-1 ring-yellow-400' :
+                              s === '💀' ? 'ring-1 ring-amber-400' :
+                              (s === '🛡' || s === '🧤') ? 'ring-1 ring-purple-400' :
                               'ring-1 ring-gray-400'
                             ) : ''}`}>{s}</span>
                           ))}


### PR DESCRIPTION
- Results page: use is_high_stakes (not playoff) for auto-assign-all non-pickers; add prior-skip-count computation for group/R32/R16 so only users with 5+ skips appear on losing side; handle draw result penalty
- Leaderboard streaks: emit skull for high-stakes and excess-skip non-picks, shield/glove for no_negative blocked losses; fetch no_negative flag and pre-compute prior skip counts efficiently
- Leaderboard UI: amber badge for skull, purple for shield/glove, with matching ring on most-recent slot