### PR TITLE
Bug Fixes & UX Improvements

### DIFF
--- a/backend/apps/matches/serializers.py
+++ b/backend/apps/matches/serializers.py
@@ -32,6 +32,7 @@ class MatchSerializer(serializers.ModelSerializer):
     allows_draw = serializers.SerializerMethodField()
     is_live = serializers.BooleanField(read_only=True)
     is_completed = serializers.BooleanField(read_only=True)
+    is_high_stakes = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = Match
@@ -43,7 +44,7 @@ class MatchSerializer(serializers.ModelSerializer):
             'scores', 'status_text',
             'home_score', 'away_score', 'minute', 'duration', 'odds',
             'allows_draw',
-            'is_live', 'is_completed', 'created_at', 'updated_at',
+            'is_live', 'is_completed', 'is_high_stakes', 'created_at', 'updated_at',
         ]
         read_only_fields = ['created_at', 'updated_at']
 

--- a/backend/apps/matches/views.py
+++ b/backend/apps/matches/views.py
@@ -36,7 +36,7 @@ class MatchViewSet(viewsets.ModelViewSet):
     - Create/update/delete: admin only
     Custom actions: /live/, /upcoming/, /completed/
     """
-    queryset = Match.objects.select_related('team1', 'team2').all()
+    queryset = Match.objects.select_related('team1', 'team2', 'tournament').all()
     serializer_class = MatchSerializer
     permission_classes = [IsAuthenticated, IsAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]

--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -217,7 +217,8 @@ def send_pick_reminders():
     total_sent = 0
     for window_key, start, end, label in windows:
         matches = (Match.objects
-                   .filter(result='TBD', datetime__gte=start, datetime__lte=end)
+                   .filter(result='TBD', datetime__gte=start, datetime__lte=end,
+                           team1__isnull=False, team2__isnull=False)
                    .select_related('team1', 'team2'))
 
         for match in matches:

--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -241,7 +241,7 @@ def send_pick_reminders():
                 body = f'{t1} vs {t2} — pick locks in {label}!'
 
                 if send_push_notification(
-                    sub, title='⏰ Pick Reminder', body=body, url='/schedule',
+                    sub, title='⏰ Pick Reminder', body=body, url=f'/match/{match.id}',
                     tag=f'pick-reminder-{match.id}'
                 ):
                     cache.set(cache_key, 1, timeout=3 * 3600)

--- a/backend/apps/picks/views.py
+++ b/backend/apps/picks/views.py
@@ -127,7 +127,8 @@ class SelectionViewSet(viewsets.ModelViewSet):
         now = datetime.now(timezone.utc)
         window = SiteSettings.get().pick_window_days
         missing_qs = Match.objects.filter(
-            result='TBD', datetime__gte=now, datetime__lte=now + timedelta(days=window)
+            result='TBD', datetime__gte=now, datetime__lte=now + timedelta(days=window),
+            team1__isnull=False, team2__isnull=False,
         ).exclude(selection__user=request.user)
         if tournament_id:
             missing_qs = missing_qs.filter(tournament_id=tournament_id)

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -110,7 +110,7 @@ function NotificationDropdown({ onClose, missingCount, isUrgent }) {
       {/* Sticky missing-picks notice */}
       {missingCount > 0 && (
         <Link
-          to="/schedule"
+          to="/schedule?unpicked=1"
           onClick={onClose}
           className="flex items-center gap-2.5 px-4 py-2.5 border-b border-gray-100"
           style={{ background: isUrgent ? '#FAEEDA' : '#E6F1FB' }}

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -284,7 +284,7 @@ export default function Leaderboard() {
       <div className="bg-white border border-gray-100 rounded-xl shadow-sm overflow-hidden">
         <div className="overflow-x-auto">
           <table className="table table-sm w-full">
-            <thead>
+            <thead className="sticky top-0 z-10 bg-white shadow-sm">
               <tr className="text-gray-500 text-xs uppercase tracking-wider">
                 <th className="w-10">#</th>
                 <th>Player</th>
@@ -357,7 +357,7 @@ export default function Leaderboard() {
       </div>
 
       <div className="text-xs text-gray-400 text-center">
-        W = Points Won · L = Points Lost · S = Skipped · MW = Matches Won
+        W = Points Won · L = Points Lost · S = Free Skips (max 5) · MW = Matches Won
       </div>
 
       {(() => {

--- a/frontend/src/pages/MatchDetail.jsx
+++ b/frontend/src/pages/MatchDetail.jsx
@@ -52,7 +52,7 @@ function MatchDetailPicker({ match, existingPick, pickStats, PM, onPickChange })
   const t1Selected = selected === match.team1?.id
   const hasPowerup = existingPick?.hidden || existingPick?.fake || existingPick?.no_negative
   const appliedPowerup = existingPick?.hidden ? 'hidden' : existingPick?.fake ? 'fake' : existingPick?.no_negative ? 'no_negative' : null
-  const powerupsDisabled = match.playoff
+  const powerupsDisabled = match.is_high_stakes
   const countdown = useCountdown(match.datetime)
 
   const showPickButtons = !isLocked && (!hasPick || showChange)

--- a/frontend/src/pages/Schedule.jsx
+++ b/frontend/src/pages/Schedule.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { matchesAPI } from '@/api/matches'
 import { picksAPI } from '@/api/picks'
 import Spinner from '@/components/ui/Spinner'
@@ -418,8 +418,16 @@ function MatchPickRow({ match, existingPick, stats }) {
   )
 }
 
+function scrollToFirstUnpicked(upcoming, pickMap) {
+  const first = upcoming.find(m => !pickMap[m.id])
+  if (!first) return
+  const el = document.getElementById(`match-${first.id}`)
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
 export default function Schedule() {
   const sentinelRef = useRef(null)
+  const [searchParams] = useSearchParams()
   const { currentTournament } = useTournamentStore()
   const tid = currentTournament?.id
 
@@ -467,6 +475,13 @@ export default function Schedule() {
   const pickMap = {}
   activePicks?.forEach(b => { pickMap[b.match] = b })
 
+  // Auto-scroll to first unpicked when arriving via ?unpicked=1
+  useEffect(() => {
+    if (searchParams.get('unpicked') !== '1') return
+    if (!upcoming.length || !activePicks) return
+    scrollToFirstUnpicked(upcoming, pickMap)
+  }, [searchParams, upcoming.length, activePicks])
+
   if (isLoading) return <Spinner />
 
   return (
@@ -474,9 +489,12 @@ export default function Schedule() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-gray-800">Schedule</h1>
         {stats?.missing_picks > 0 && (
-          <span className="badge badge-warning gap-1">
-            ⚠ {stats.missing_picks} missing pick{stats.missing_picks !== 1 ? 's' : ''}
-          </span>
+          <button
+            onClick={() => scrollToFirstUnpicked(upcoming, pickMap)}
+            className="badge badge-warning gap-1 cursor-pointer"
+          >
+            ⚠ {stats.missing_picks} missing pick{stats.missing_picks !== 1 ? 's' : ''} ↓
+          </button>
         )}
       </div>
 
@@ -504,12 +522,13 @@ export default function Schedule() {
         </div>
       ) : (
         upcoming.map(m => (
-          <MatchPickRow
-            key={m.id}
-            match={m}
-            existingPick={pickMap[m.id] ?? null}
-            stats={stats}
-          />
+          <div key={m.id} id={`match-${m.id}`}>
+            <MatchPickRow
+              match={m}
+              existingPick={pickMap[m.id] ?? null}
+              stats={stats}
+            />
+          </div>
         ))
       )}
 


### PR DESCRIPTION
Fixes include: false urgent/missing-pick alerts, duplicate push notifications from API status bouncing, powerups blocked in R32, penalty picks invisible on Results, and N+1 tournament queries. Added soccer Dummy powerup decoy picker, streak badges for penalty picks and blocked losses, and scroll-to-first-unpicked on Schedule page.
Closes #38 ,
Closes #39 ,
Closes #40 