### PR TITLE
Hide draw odds for playoff matches using draw_no_bet or h2h re-normal…

### DIFF
--- a/backend/apps/matches/oddsapi.py
+++ b/backend/apps/matches/oddsapi.py
@@ -121,6 +121,29 @@ def _consensus_h2h(bookmakers, home_team, away_team):
     return result
 
 
+def _consensus_dnb(bookmakers, home_team, away_team):
+    """Average draw-no-bet decimal odds across bookmakers."""
+    home_prices, away_prices = [], []
+    for bm in bookmakers:
+        for market in bm.get('markets', []):
+            if market['key'] != 'draw_no_bet':
+                continue
+            for outcome in market['outcomes']:
+                n = _normalize_name(outcome['name'])
+                p = outcome['price']
+                if n == _normalize_name(home_team):
+                    home_prices.append(p)
+                elif n == _normalize_name(away_team):
+                    away_prices.append(p)
+
+    result = {}
+    if home_prices:
+        result['home'] = round(statistics.mean(home_prices), 3)
+    if away_prices:
+        result['away'] = round(statistics.mean(away_prices), 3)
+    return result
+
+
 def _consensus_totals(bookmakers):
     """Find most common line value and average odds for that line."""
     line_data = {}  # line -> {'over': [], 'under': []}
@@ -269,6 +292,7 @@ def fetch_and_store_odds():
             away_team_name = event['away_team']
 
             h2h = _consensus_h2h(bookmakers, home_team_name, away_team_name)
+            dnb = _consensus_dnb(bookmakers, home_team_name, away_team_name)
             totals = _consensus_totals(bookmakers)
             spread = _consensus_spread(bookmakers, home_team_name)
 
@@ -282,12 +306,16 @@ def fetch_and_store_odds():
                     'team1': h2h.get('home'),
                     'draw': h2h.get('draw'),
                     'team2': h2h.get('away'),
+                    'team1_dnb': dnb.get('home'),
+                    'team2_dnb': dnb.get('away'),
                 }
             else:
                 odds_data = {
                     'team1': h2h.get('away'),
                     'draw': h2h.get('home'),
                     'team2': h2h.get('away'),
+                    'team1_dnb': dnb.get('away'),
+                    'team2_dnb': dnb.get('home'),
                 }
                 # When home is team2, swap favored side too
                 if spread.get('spread_favored') == 'team1':

--- a/frontend/src/components/home/HomeMatchCard.jsx
+++ b/frontend/src/components/home/HomeMatchCard.jsx
@@ -362,7 +362,7 @@ export default function HomeMatchCard({ match, pick, stats, isDragTarget, onDrag
 
         {/* Odds bar */}
         {match.odds && match.result === 'TBD' && (
-          <OddsBarCompact odds={match.odds} team1Name={match.team1?.name} team2Name={match.team2?.name} />
+          <OddsBarCompact odds={match.odds} team1Name={match.team1?.name} team2Name={match.team2?.name} playoff={match.playoff} />
         )}
 
         {/* Pick distribution */}

--- a/frontend/src/components/match/OddsBar.jsx
+++ b/frontend/src/components/match/OddsBar.jsx
@@ -3,8 +3,29 @@
  * Used in Schedule (compact) and MatchDetail (full).
  */
 
-function impliedProbs(odds) {
+function impliedProbs(odds, playoff = false) {
   if (!odds) return null
+
+  // For playoff matches use draw_no_bet odds if available, otherwise
+  // re-normalise h2h across team1/team2 only (drop draw).
+  if (playoff) {
+    if (odds.team1_dnb && odds.team2_dnb && odds.team1_dnb > 1 && odds.team2_dnb > 1) {
+      const r1 = 1 / odds.team1_dnb
+      const r2 = 1 / odds.team2_dnb
+      const t  = r1 + r2
+      return { team1: Math.round((r1 / t) * 100), team2: Math.round((r2 / t) * 100) }
+    }
+    // Fallback: re-normalise h2h without draw
+    const entries = [
+      { key: 'team1', val: odds.team1 },
+      { key: 'team2', val: odds.team2 },
+    ].filter(e => e.val && e.val > 1)
+    if (entries.length < 2) return null
+    const raws = entries.map(e => ({ key: e.key, raw: 1 / e.val }))
+    const total = raws.reduce((s, e) => s + e.raw, 0)
+    return Object.fromEntries(raws.map(e => [e.key, Math.round((e.raw / total) * 100)]))
+  }
+
   const entries = [
     { key: 'team1', val: odds.team1 },
     { key: 'draw',  val: odds.draw  },
@@ -20,8 +41,8 @@ function impliedProbs(odds) {
 
 // ─── Compact bar for Schedule ────────────────────────────────────────────────
 
-export function OddsBarCompact({ odds, team1Name, team2Name }) {
-  const probs = impliedProbs(odds)
+export function OddsBarCompact({ odds, team1Name, team2Name, playoff = false }) {
+  const probs = impliedProbs(odds, playoff)
   if (!probs) return null
 
   const segments = [
@@ -75,8 +96,8 @@ function ProbBar({ label, pct, color, bgColor }) {
   )
 }
 
-export function OddsCardFull({ odds, team1Name, team2Name }) {
-  const probs = impliedProbs(odds)
+export function OddsCardFull({ odds, team1Name, team2Name, playoff = false }) {
+  const probs = impliedProbs(odds, playoff)
   if (!probs || !odds) return null
 
   const hasTotals = odds.total_line != null && (odds.over_odds || odds.under_odds)
@@ -103,7 +124,7 @@ export function OddsCardFull({ odds, team1Name, team2Name }) {
 
         {/* Win probability */}
         <div className="space-y-2">
-          <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">Win Probability</p>
+          <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">{playoff ? 'To Advance' : 'Win Probability'}</p>
           <ProbBar label={team1Name} pct={probs.team1} color="#93C5FD" bgColor="#1e3a5f" />
           {probs.draw != null && (
             <ProbBar label="Draw" pct={probs.draw} color="#FCD34D" bgColor="#7c5005" />

--- a/frontend/src/pages/MatchDetail.jsx
+++ b/frontend/src/pages/MatchDetail.jsx
@@ -458,6 +458,7 @@ export default function MatchDetail() {
           odds={match.odds}
           team1Name={match.team1?.name}
           team2Name={match.team2?.name}
+          playoff={match.playoff}
         />
       )}
 

--- a/frontend/src/pages/Schedule.jsx
+++ b/frontend/src/pages/Schedule.jsx
@@ -271,7 +271,7 @@ function MatchPickRow({ match, existingPick, stats }) {
 
         {/* Odds bar */}
         {match.odds && match.result === 'TBD' && (
-          <OddsBarCompact odds={match.odds} team1Name={match.team1?.name} team2Name={match.team2?.name} />
+          <OddsBarCompact odds={match.odds} team1Name={match.team1?.name} team2Name={match.team2?.name} playoff={match.playoff} />
         )}
 
         {/* Pick distribution */}


### PR DESCRIPTION
…isation

Fetches draw_no_bet market from The Odds API (stored as team1_dnb/team2_dnb) when available. OddsBar components accept a playoff prop — for knockout matches the draw segment is hidden and probabilities are re-normalised across team1/team2 only. Falls back to h2h re-normalisation when DNB odds are absent (as is the case for soccer_fifa_world_cup). Full card labels the section "To Advance" instead of "Win Probability" for playoff matches.