### PR TITLE
Prevent playoff matches from being set as draw

### DIFF
--- a/backend/apps/matches/footballapi.py
+++ b/backend/apps/matches/footballapi.py
@@ -50,7 +50,7 @@ _KNOCKOUT_STAGES = frozenset({
 
 # ── Pure mapping functions ────────────────────────────────────────────────────
 
-def map_status(status: str, winner: str | None, home_score=None, away_score=None) -> str | None:
+def map_status(status: str, winner: str | None, home_score=None, away_score=None, playoff=False) -> str | None:
     """Map API status + winner → internal Match.result value, or None to skip."""
     if status in ('SCHEDULED', 'TIMED'):
         return 'TBD'
@@ -62,7 +62,10 @@ def map_status(status: str, winner: str | None, home_score=None, away_score=None
         if winner == 'AWAY_TEAM':
             return 'team2'
         if winner == 'DRAW':
-            return 'draw'
+            # Playoff matches cannot end in a draw — a DRAW winner at the end of
+            # extra time means the match is heading to a penalty shootout.
+            # Keep it as in-progress until we have a definitive winner.
+            return 'IP' if playoff else 'draw'
         # winner null — fall back to fullTime scores when available.
         # Covers penalty shootouts where some providers omit the winner field.
         if home_score is not None and away_score is not None and home_score != away_score:

--- a/backend/apps/matches/tasks.py
+++ b/backend/apps/matches/tasks.py
@@ -314,7 +314,7 @@ def fetch_football_matches(tournament_id=None):
                     tournament=tournament,
                     description=map_stage(stage, group),
                     datetime=match_dt,
-                    result=map_status(status, winner, full_time.get('home'), full_time.get('away')),
+                    result=map_status(status, winner, full_time.get('home'), full_time.get('away'), playoff=map_playoff(stage)),
                     match_points=map_points(stage),
                     playoff=map_playoff(stage),
                     home_score=full_time.get('home'),
@@ -407,7 +407,7 @@ def sync_football_scores():
                 score = m.get('score') or {}
                 full_time = score.get('fullTime') or {}
                 api_status   = m.get('status', '')
-                new_result   = map_status(api_status, score.get('winner'), full_time.get('home'), full_time.get('away'))
+                new_result   = map_status(api_status, score.get('winner'), full_time.get('home'), full_time.get('away'), playoff=match.playoff)
                 if new_result is None:
                     continue  # FINISHED with null winner and no score fallback — skip
                 new_home     = full_time.get('home')


### PR DESCRIPTION
football-data.org sends FINISHED+winner=DRAW at the end of extra time in knockout matches as an intermediate state before penalty shootout. Treat this as in-progress for playoff matches so the result stays live until a definitive winner is determined from the penalty shootout.